### PR TITLE
Further cleanup of media views

### DIFF
--- a/720p/DialogProgress.xml
+++ b/720p/DialogProgress.xml
@@ -59,44 +59,18 @@
         <aligny>center</aligny>
         <textcolor>white</textcolor>
       </control>
-      <control type="label" id="2">
-        <description>dialog line 1</description>
+      </control>
+      <control type="textbox" id="9">
+        <description>text</description>
         <left>20</left>
         <top>60</top>
         <width>560</width>
         <height>30</height>
-        <align>left</align>
-        <aligny>center</aligny>
+        <align>center</align>
         <label>-</label>
-        <haspath>true</haspath>
-        <font>Font_Neon_16</font>
+        <font>Font_Neon_20</font>
         <textcolor>white</textcolor>
-      </control>
-      <control type="label" id="3">
-        <description>dialog line 2</description>
-        <left>20</left>
-        <top>85</top>
-        <width>560</width>
-        <height>30</height>
-        <align>left</align>
-        <aligny>center</aligny>
-        <label>-</label>
-        <haspath>true</haspath>
-        <font>Font_Neon_16</font>
-        <textcolor>white</textcolor>
-      </control>
-      <control type="label" id="4">
-        <description>dialog line 3</description>
-        <left>20</left>
-        <top>110</top>
-        <width>560</width>
-        <height>30</height>
-        <align>left</align>
-        <aligny>center</aligny>
-        <label>-</label>
-        <haspath>true</haspath>
-        <font>Font_Neon_16</font>
-        <textcolor>white</textcolor>
+        <autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
       </control>
       <control type="progress">
         <description>Progressbar</description>

--- a/720p/DialogVideoInfo.xml
+++ b/720p/DialogVideoInfo.xml
@@ -1214,16 +1214,14 @@
             <description>Play Trailer</description>
             <include>ButtonInfoDialogsCommonValues</include>
             <label>$LOCALIZE[20410]</label>
-            <visible>!IsEmpty(ListItem.Trailer) + Skin.HasSetting(big_trailer)</visible>
-            <onclick>PlayMedia($ESCINFO[ListItem.Trailer],noresume</onclick>
+            <visible>!IsEmpty(ListItem.Trailer) + !Skin.HasSetting(WindowedTrailer)</visible>
           </control>
           <control type="button" id="15">
-            <description>Play Trailer</description>
+            <description>Play Trailer Windowed</description>
             <include>ButtonInfoDialogsCommonValues</include>
             <label>$LOCALIZE[20410]</label>
-            <visible>!IsEmpty(ListItem.Trailer) + !Skin.HasSetting(big_trailer)</visible>
-            <onclick>Dialog.Close(MovieInformation)</onclick>
-            <onclick>PlayMedia($ESCINFO[ListItem.Trailer],1)</onclick>
+            <onclick>PlayMedia($INFO[ListItem.Trailer],1)</onclick>
+            <visible>!IsEmpty(ListItem.Trailer) + Skin.HasSetting(WindowedTrailer)</visible>
           </control>
           <control type="button" id="113">
             <description>Cinema Script</description>

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -20,7 +20,7 @@
   <include file="Viewtype_Songs.xml" />
   <include file="Viewtype_16x9.xml" />
   <include file="Viewtype_Wall.xml" />
-  <!-- <include file="Viewtype_WallPanel.xml" /> -->
+  <include file="Viewtype_WallPanel.xml" />
   <include file="Viewtype_Shelf.xml" />
   <include file="Viewtype_addons.xml" />
   <include file="Viewtype_3dbanner.xml" />
@@ -1199,6 +1199,15 @@
       <aligny>center</aligny>
       <visible>[Player.HasAudio | Player.HasVideo]</visible>
       <include>VisibleFadeEffect</include>
+    </control>
+    <control type="image" id="224">
+      <description>separator</description>
+      <left>-250</left>
+      <top>240</top>
+      <width>240</width>
+      <aspectratio>keep</aspectratio>
+      <colordiffuse>mainblue</colordiffuse>
+      <texture>separator2.png</texture>
     </control>
     <control type="button" id="610">
       <description>Fake Button to fix Player Controls Navigation</description>

--- a/720p/Includes_Trailer.xml
+++ b/720p/Includes_Trailer.xml
@@ -10,7 +10,7 @@
       <!--Landscape TVshows-->
       <left>740</left>
       <top>730</top>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>-20</top>
         <width>540</width>
@@ -45,7 +45,7 @@
         <height>445</height>
         <texture>dialogs/trailer_diffuse_back.png</texture>
       </control>
-      <control type="videowindow" id="4">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>500</width>
@@ -79,7 +79,7 @@
         <height>395</height>
         <texture>tv-episodes/context-back.png</texture>
       </control>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>700</width>
@@ -113,7 +113,7 @@
         <height>420</height>
         <texture>tv-episodes/context-back.png</texture>
       </control>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>34</left>
         <top>27</top>
         <width>750</width>
@@ -138,7 +138,7 @@
       <!--Landscape TVshows-->
       <left>30</left>
       <top>30</top>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>700</width>
@@ -171,7 +171,7 @@
         <height>400</height>
         <texture>tv-episodes/context-back.png</texture>
       </control>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>700</width>
@@ -212,7 +212,7 @@
         <height>295</height>
         <texture>tv-episodes/context-back.png</texture>
       </control>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>15</top>
         <width>531</width>
@@ -244,7 +244,7 @@
         <height>295</height>
         <texture>tv-episodes/context-back.png</texture>
       </control>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>15</top>
         <width>531</width>
@@ -268,7 +268,7 @@
       <animation effect="zoom" start="0" end="66" time="400" delay="800" condition="Player.HasVideo">Conditional</animation>
       <left>0</left>
       <top>0</top>
-      <control type="videowindow" id="7">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>500</width>
@@ -292,7 +292,7 @@
       <animation effect="fade" start="0" end="100" time="400" delay="800" condition="Player.HasVideo">Conditional</animation>
       <left>1380</left>
       <top>95</top>
-      <control type="videowindow" id="8">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>26</top>
         <width>600</width>
@@ -340,7 +340,7 @@
       <animation effect="fade" start="0" end="100" time="400" delay="800" condition="Player.HasVideo">Conditional</animation>
       <left>0</left>
       <top>1075</top>
-      <control type="videowindow" id="2">
+      <control type="videowindow" id="9">
         <left>30</left>
         <top>15</top>
         <width>531</width>

--- a/720p/MyMusicNav.xml
+++ b/720p/MyMusicNav.xml
@@ -52,35 +52,22 @@
 			<visible>Control.IsVisible(53) | Control.IsVisible(52)</visible>
 		</control> -->
     <control type="group">
-      <include>Viewtype_Files</include>
-      <!-- 50 -->
-      <include>Viewtype_MusicShowcase</include>
-      <!-- 58 -->
-      <include>Viewtype_3daddon</include>
-      <!-- 56 -->
-      <include>Viewtype_Songs</include>
-      <!-- 52 -->
-      <include>Viewtype_Shelf</include>
-      <!-- 51 -->
-      <include>Viewtype_JukeBox</include>
-      <!-- 54 -->
-      <include>Viewtype_List</include>
-      <!-- 53 -->
-      <include>ThumbnailView</include>
-      <!-- 500 -->
-      <include>MusicInfoListView</include>
-      <!-- 506 -->
-      <!--<include>AlbumWrapView2_Fanart</include>  -->
-      <!-- 509 Need to fix this view and remove hidden aspect -->
-      <include>MusicVideoInfoListView</include>
-      <!-- 511 -->
-      <include>ArtistMediaListView</include>
-      <!-- 512 -->
-      <include>AlbumInfoListView</include>
-      <!-- 513 -->
-      <include>Viewtype_MusicLogo</include>
-      <include>Viewtype_SlimFiles</include>
-      <!-- 598 -->
+      <include>Viewtype_Files</include> <!-- 50 -->
+      <include>MusicVideoInfoListView</include> <!-- 511 -->
+      <include>AlbumInfoListView</include> <!-- 513 -->
+      <include>Viewtype_SlimFiles</include> <!-- 598 -->
+      <include>Viewtype_MusicLogo</include> <!-- 599 -->
+      <include>ArtistMediaListView</include> <!-- 512 -->
+      <include>Viewtype_3daddon</include> <!-- 56 -->
+      <include>Viewtype_MusicShowcase</include> <!-- 58 -->
+      <include>Viewtype_Shelf</include> <!-- 51 -->
+      <include>Viewtype_Songs</include> <!-- 52 -->
+      <include>Viewtype_JukeBox</include> <!-- 54 -->
+      <include>Viewtype_List</include> <!-- 53 -->
+      <include>ThumbnailView</include> <!-- 500 -->
+      <include>MusicInfoListView</include> <!-- 506 -->
+      <!--<include>AlbumWrapView2_Fanart</include>  -->  <!-- 509 Need to fix this view and remove hidden aspect -->
+      <include>Viewtype_Landscape_Fanart</include> <!-- 633 -->
     </control>
     <control type="group">
       <include>Animation_HiddenByInfo</include>
@@ -89,37 +76,38 @@
     <include>Time</include>
     <include>Library Totals</include>
     <include>ScrollOffsetLabel</include>
-    <include>7000_has_focus</include>
     <control type="group">
-      <visible>!Skin.HasSetting(LockViews)</visible>
-      <include>Animation_CommonFade_ViewOptions</include>
-      <control type="image">
-        <!-- Floor -->
-        <left>0</left>
-        <top>555</top>
-        <width>1280</width>
-        <height>160</height>
-        <colordiffuse>mainblue</colordiffuse>
-        <texture>mainmenu/home_bottom_backthin.png</texture>
-        <visible allowhiddenfocus="true">ControlGroup(7000).HasFocus() + !Skin.HasSetting(LockViews)</visible>
-      </control>
-      <control type="image">
-        <!-- Floor -->
-        <left>0</left>
-        <top>555</top>
-        <width>1280</width>
-        <height>160</height>
-        <texture>mainmenu/home_bottom_align.png</texture>
-        <visible allowhiddenfocus="true">ControlGroup(7000).HasFocus() + !Skin.HasSetting(LockViews)</visible>
-      </control>
+      <include>Animation_SettingsFade</include>
+      <animation effect="slide" start="-10,0" end="250,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(7000).HasFocus()">Conditional</animation>
+      <animation effect="slide" start="0,0" end="-250,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(7000).HasFocus()">WindowClose</animation>
+      <include>SideBladeLeft</include>
       <control type="grouplist" id="7000">
-        <visible>!Skin.HasSetting(LockViews)</visible>
-        <include>WindowMenuVars</include>
-        <top>680</top>
-        <control type="button" id="20">
-          <include>WindowMenuButton</include>
-          <label>$INFO[Container.ViewMode]</label>
-          <onclick>Container.NextViewMode</onclick>
+        <left>-250</left>
+        <top>30</top>
+        <include>WindowMenuVars_Vertical</include>
+        <control type="label" id="204">
+          <width>250</width>
+          <height>35</height>
+          <font>Font_Neon_26</font>
+          <label>$LOCALIZE[31513]</label>
+          <textcolor>mainblue</textcolor>
+          <align>center</align>
+          <aligny>center</aligny>
+        </control>
+        <control type="image" id="203">
+          <description>separator</description>
+          <left>-250</left>
+          <top>40</top>
+          <width>240</width>
+          <aspectratio>keep</aspectratio>
+          <colordiffuse>mainblue</colordiffuse>
+          <texture>separator2.png</texture>
+        </control>
+        <control type="button" id="2">
+          <include>WindowMenuButton_Vertical</include>
+          <description>View As button</description>
+          <textwidth>235</textwidth>
+          <label>-</label>
         </control>
         <control type="togglebutton" id="26">
           <description>Toggle MoviesFanart</description>
@@ -154,57 +142,84 @@
           <visible>Control.IsVisible(598)</visible>
         </control>
         <control type="button" id="3">
-          <include>WindowMenuButton</include>
+          <include>WindowMenuButton_Vertical</include>
           <label>103</label>
         </control>
-        <control type="button" id="5">
-          <include>WindowMenuButton</include>
-          <label>$LOCALIZE[744]</label>
+        <control type="togglebutton" id="4">
+          <include>WindowMenuButton_Vertical</include>
+          <!-- Sort Ascending -->
+          <label>$LOCALIZE[31511]</label>
+          <!-- Sort Descending -->
+          <altlabel>$LOCALIZE[31512]</altlabel>
+        </control>
+        <control type="radiobutton" id="99">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Library button</description>
+          <label>$LOCALIZE[29800]</label>
+          <onclick>ReplaceWindow(MusicFiles)</onclick>
+          <selected>Window.IsVisible(MusicLibrary)</selected>
+        </control>
+        <control type="edit" id="19">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Filter</description>
+          <textwidth>230</textwidth>
+          <label>587</label>
+        </control>
+        <control type="label" id="201">
+          <width>250</width>
+          <height>35</height>
+          <font>font12caps</font>
+          <label>31026</label>
+          <textcolor>mainblue</textcolor>
+          <align>center</align>
+          <aligny>center</aligny>
+        </control>
+        <control type="image" id="222">
+          <description>separator</description>
+          <left>-250</left>
+          <top>240</top>
+          <width>240</width>
+          <aspectratio>keep</aspectratio>
+          <colordiffuse>mainblue</colordiffuse>
+          <texture>separator2.png</texture>
+        </control>
+        <control type="button" id="8">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Search</description>
+          <label>137</label>
         </control>
         <control type="radiobutton" id="16">
-          <include>WindowMenuButton</include>
+          <include>WindowMenuButton_Vertical</include>
           <label>589</label>
         </control>
-        <control type="togglebutton" id="4">
-          <include>WindowMenuButton</include>
-          <label>$LOCALIZE[584]</label>
-          <altlabel>$LOCALIZE[585]</altlabel>
+        <control type="label" id="205">
+          <width>250</width>
+          <height>35</height>
+          <font>font12caps</font>
+          <label>31028</label>
+          <textcolor>mainblue</textcolor>
+          <align>center</align>
+          <aligny>center</aligny>
         </control>
-      </control>
-      <control type="grouplist">
-        <visible>!Skin.HasSetting(LockViews)</visible>
-        <include>WindowMenuVars</include>
-        <top>660</top>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31088]</label>
+        <control type="image" id="223">
+          <description>separator</description>
+          <left>-250</left>
+          <top>240</top>
+          <width>240</width>
+          <aspectratio>keep</aspectratio>
+          <colordiffuse>mainblue</colordiffuse>
+          <texture>separator2.png</texture>
         </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>Icon/Logo</label>
-          <visible>Control.IsVisible(598)</visible>
+        <control type="togglebutton" id="20">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Update library</description>
+          <textwidth>235</textwidth>
+          <label>653</label>
+          <altlabel>13353</altlabel>
+          <usealttexture>library.isscanningvideo</usealttexture>
         </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[14018]</label>
-          <visible>Control.IsVisible(53) | Control.IsVisible(50) | Control.IsVisible(56) | Control.IsVisible(58)</visible>
-        </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31090]</label>
-        </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[240]</label>
-        </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[14086]</label>
-        </control>
-        <control type="label">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31093]</label>
-        </control>
+        <include>CommonNowPlaying_Controls</include>
+        <include>CommonNowPlaying</include>
       </control>
     </control>
     <!--<include>Global_RSS</include>-->

--- a/720p/MyMusicSongs.xml
+++ b/720p/MyMusicSongs.xml
@@ -30,41 +30,46 @@
       <include>Animation_MyVideoNav_Fanart</include>
       <visible>IsEmpty(ListItem.Property(Fanart_Image))</visible>
     </control>
-    <include>Viewtype_List</include>
-    <!-- 50 -->
-    <include>Viewtype_Files</include>
-    <!-- 55  -->
-    <include>Viewtype_JukeBox</include>
-    <!-- 54 -->
-    <include>Viewtype_MusicShowcase</include>
-    <!-- 58 -->
-    <include>Viewtype_3daddon</include>
-    <!-- 56 -->
-    <include>Viewtype_Songs</include>
-    <!-- 52 -->
+    <include>Viewtype_List</include> <!-- 50 -->
+    <include>Viewtype_Files</include> <!-- 55  -->
+    <include>Viewtype_JukeBox</include> <!-- 54 -->
+    <include>Viewtype_MusicShowcase</include> <!-- 58 -->
+    <include>Viewtype_3daddon</include> <!-- 56 -->
+    <include>Viewtype_Songs</include> <!-- 52 -->
     <include>Time</include>
     <include>ScrollOffsetLabel</include>
-    <include>7000_has_focus</include>
     <control type="group">
-      <visible>!Skin.HasSetting(LockViews)</visible>
-      <include>Animation_CommonFade_ViewOptions</include>
-      <control type="image">
-        <!-- Floor -->
-        <left>0</left>
-        <top>650</top>
-        <width>1280</width>
-        <height>70</height>
-        <texture>notification_background.png</texture>
-        <visible allowhiddenfocus="true">ControlGroup(7000).HasFocus() + !Skin.HasSetting(LockViews)</visible>
-      </control>
+      <include>Animation_SettingsFade</include>
+      <animation effect="slide" start="-10,0" end="250,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(7000).HasFocus()">Conditional</animation>
+      <animation effect="slide" start="0,0" end="-250,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(7000).HasFocus()">WindowClose</animation>
+      <include>SideBladeLeft</include>
       <control type="grouplist" id="7000">
-        <visible>!Skin.HasSetting(LockViews)</visible>
-        <include>WindowMenuVars</include>
-        <top>680</top>
-        <control type="button" id="20">
-          <include>WindowMenuButton</include>
-          <label>$INFO[Container.ViewMode]</label>
-          <onclick>Container.NextViewMode</onclick>
+        <left>-250</left>
+        <top>30</top>
+        <include>WindowMenuVars_Vertical</include>
+        <control type="label" id="204">
+          <width>250</width>
+          <height>35</height>
+          <font>Font_Neon_26</font>
+          <label>$LOCALIZE[31513]</label>
+          <textcolor>mainblue</textcolor>
+          <align>center</align>
+          <aligny>center</aligny>
+        </control>
+        <control type="image" id="203">
+          <description>separator</description>
+          <left>-250</left>
+          <top>40</top>
+          <width>240</width>
+          <aspectratio>keep</aspectratio>
+          <colordiffuse>mainblue</colordiffuse>
+          <texture>separator2.png</texture>
+        </control>
+        <control type="button" id="2">
+          <include>WindowMenuButton_Vertical</include>
+          <description>View As button</description>
+          <textwidth>235</textwidth>
+          <label>-</label>
         </control>
         <control type="togglebutton" id="22">
           <description>Toggle MoviesFanart</description>
@@ -75,52 +80,35 @@
           <visible>Control.IsVisible(58)</visible>
         </control>
         <control type="button" id="3">
-          <include>WindowMenuButton</include>
-          <label>103</label>
+          <include>WindowMenuButton_Vertical</include>
+          <label>$LOCALIZE[103]</label>
         </control>
-        <control type="button" id="21">
-          <include>WindowMenuButton</include>
-          <label>$LOCALIZE[14022]</label>
+        <control type="togglebutton" id="4">
+          <include>WindowMenuButton_Vertical</include>
+          <!-- Sort Ascending -->
+          <label>$LOCALIZE[31511]</label>
+          <!-- Sort Descending -->
+          <altlabel>$LOCALIZE[31512]</altlabel>
+        </control>
+        <control type="radiobutton" id="99">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Library button</description>
+          <label>$LOCALIZE[29800]</label>
           <onclick>ReplaceWindow(MusicLibrary)</onclick>
+          <selected>Window.IsVisible(MusicLibrary)</selected>
         </control>
-        <control type="radiobutton" id="16">
-          <include>WindowMenuButton</include>
-          <label>589</label>
+        <control type="edit" id="19">
+          <include>WindowMenuButton_Vertical</include>
+          <description>Filter</description>
+          <textwidth>230</textwidth>
+          <label>$LOCALIZE[587]</label>
         </control>
-        <control type="button" id="9">
-          <include>WindowMenuButton</include>
+        <!-- <control type="button" id="9">
+          <include>WindowMenuButton_Vertical</include>
           <label>$LOCALIZE[590]</label>
-        </control>
-      </control>
-      <control type="grouplist">
-        <visible>!Skin.HasSetting(LockViews)</visible>
-        <include>WindowMenuVars</include>
-        <top>660</top>
-        <control type="button" id="40">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31088]</label>
-        </control>
-        <control type="button" id="45">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[14018]</label>
-          <visible>Control.IsVisible(58)</visible>
-        </control>
-        <control type="button" id="41">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31090]</label>
-        </control>
-        <control type="button" id="42">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[240]</label>
-        </control>
-        <control type="button" id="43">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[14086]</label>
-        </control>
-        <control type="button" id="44">
-          <include>WindowMenuLabel</include>
-          <label>$LOCALIZE[31093]</label>
-        </control>
+        </control> -->
+        <include>CommonNowPlaying_Controls</include>
+        <include>CommonNowPlaying</include>
       </control>
     </control>
   </controls>

--- a/720p/MyVideoNav.xml
+++ b/720p/MyVideoNav.xml
@@ -5,7 +5,7 @@
   <onload condition="!SubString(Window(Videos).Property(CinemaExperienceRunning),True) + [Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]">RunScript(script.tv.show.next.aired,backend=True)</onload>
   <defaultcontrol always="true">50</defaultcontrol>
   <allowoverlay>yes</allowoverlay>
-  <views>50,55,58,558,595,51,596,52,633,594,53,504,503,54,597,56,57,59,500,501,508,592,593,598,599,588</views>
+  <views>50,55,58,558,595,51,596,52,633,594,53,503,54,597,56,57,59,500,501,508,592,593,598,599,588</views>
   <controls>
     <!-- <control type="button" id="9999">
             <description>trigger</description>
@@ -107,60 +107,42 @@
       <include>Animation_MyVideoNav_Fanart</include>
       <visible>Control.IsVisible(59) | [Control.IsVisible(58) + !Skin.HasSetting(ShowcaseFanart)]</visible>
     </control>
-    <include>Viewtype_Showcase</include>
-    <!--  58  -->
-    <include>Viewtype_Poster</include>
-    <!--  55  -->
-    <include>Viewtype_Files</include>
-    <!--  50  -->
-    <include>Viewtype_Landscape</include>
-    <!--  52  -->
-    <include>Viewtype_Landscape_Fanart</include>
-    <!--  633  -->
-    <include>Viewtype_List</include>
-    <!--  53  -->
-    <include>Viewtype_Episode</include>
-    <!--  51  -->
-    <include>Viewtype_Wall</include>
-    <!--  54  -->
-    <include>Viewtype_Panel</include>
-    <!--  56  TV=Panel -->
-    <include>Viewtype_PanelLandscape</include>
-    <!--  57  -->
-    <include>Viewtype_BannerPanel</include>
-    <!--  592  -->
-    <include>Viewtype_WallPanel</include>
-    <!--  597  -->
-    <include>Viewtype_16x9</include>
-    <!--  59  -->
-    <include>Viewtype_3dbanner</include>
-    <!--  593  -->
-    <include>Viewtype_Logo</include>
-    <!--  594  -->
-    <include>Viewtype_Slide</include>
-    <!--  595  -->
-    <include>Viewtype_Newest_Episodes</include>
-    <!--  596  -->
-    <include>Viewtype_SlimFiles</include>
-    <!--598 -->
-    <include>PosterWrapView2_Fanart</include>
-    <!-- 508 -->
-    <include>MediaListView3</include>
-    <!-- 503 -->
-    <include>Viewtype_3DLandscape</include>
-    <!-- 599 -->
-    <include>Viewtype_Multiplex</include>
-    <!-- 588 -->
-    <include>Viewtype_Coverflow</include>
-    <!-- 558 -->
-    <include>Trailer</include>
-    <include>Trailer_TVLandscape</include>
-    <include>Trailer_Landscape_Fanart</include>
-    <include>Trailer_16x9</include>
-    <include>Trailer_Files</include>
-    <include>Trailer_Poster</include>
-    <include>ScrollOffsetLabel</include>
-    <include>Trailer_Media_View</include>
+    <control type="group">
+      <include>Viewtype_Files</include> <!--  view id 50  -->
+      <include>Viewtype_Poster</include> <!--  view id 55  -->
+      <include>Viewtype_Showcase</include> <!--  view id 58  -->
+      <include>Viewtype_Coverflow</include> <!--  view id 558  -->
+      <include>Viewtype_Slide</include> <!--  view id 595  -->
+      <include>Viewtype_Episode</include> <!--  view id 51  -->
+      <include>Viewtype_Newest_Episodes</include> <!--  view id 596  -->
+      <include>Viewtype_Landscape</include> <!--  view id 52  -->
+      <include>Viewtype_Landscape_Fanart</include> <!--  view id 633  -->
+      <include>Viewtype_Logo</include> <!--  view id 594  -->
+      <include>Viewtype_List</include> <!--  view id 53 Media View  -->
+      <include>MediaListView3</include> <!--  view id 503  -->
+      <include>Viewtype_Wall</include> <!--  view id 54  -->
+      <include>Viewtype_WallPanel</include> <!--  view id 597  -->
+      <include>Viewtype_Panel</include> <!--  view id 56  TV=Panel -->
+      <include>Viewtype_PanelLandscape</include> <!--  view id 57  -->
+      <include>Viewtype_16x9</include> <!--  view id 59  -->
+      <include>ThumbnailView</include> <!--  view id 500  -->
+      <include>PosterWrapView</include> <!--  view id 501  -->
+      <include>PosterWrapView2_Fanart</include> <!--  view id 508  -->
+      <include>Viewtype_BannerPanel</include> <!--  view id 592  -->
+      <include>Viewtype_3dbanner</include> <!--  view id 593  -->
+      <include>Viewtype_SlimFiles</include> <!--  view id 598  -->
+      <include>Viewtype_3DLandscape</include> <!--  view id 599  -->
+      <include>Viewtype_Multiplex</include> <!--  view id 588  -->
+      <include>Trailer</include>
+      <include>Trailer_TVLandscape</include>
+      <include>Trailer_Landscape_Fanart</include>
+      <include>Trailer_16x9</include>
+      <include>Trailer_Files</include>
+      <include>Trailer_Poster</include>
+      <include>Trailer_Media_View</include>
+      <include>Trailer_Multiplex</include>
+      <include>ScrollOffsetLabel</include>
+    </control>
     <control type="group">
       <visible>!SubString(Window(25).Property(tvtunesIsAlive),True)</visible>
       <include>RSS_Music</include>
@@ -203,10 +185,9 @@
           <colordiffuse>mainblue</colordiffuse>
           <texture>separator2.png</texture>
         </control>
-        <control type="button" id="98">
+        <control type="button" id="2" description="Views">
           <include>WindowMenuButton_Vertical</include>
-          <label>$INFO[Container.ViewMode]</label>
-          <onclick>Container.NextViewMode</onclick>
+          <label>-</label>
           <visible>!Skin.HasSetting(LockViews)</visible>
         </control>
         <control type="togglebutton" id="22">


### PR DESCRIPTION
Please review the proposed changes.  

The main changes on the video side were to bring the views in line with the current documented button IDs here: http://wiki.xbmc.org/index.php?title=List_of_Built_In_Controls#MyVideoNav.xml  The main issue was with button ID 2 being used for the trailer controls I believe.

The changes to the audio side brought the view and library controls to the left side blade, similar to the video view.  I believe this lends itself to a more consistent navigation feel in the skin (versus having differing menu options on the video and music sides).
