### PR TITLE
Further Gotham updates

### DIFF
--- a/720p/DialogPVRChannelsOSD.xml
+++ b/720p/DialogPVRChannelsOSD.xml
@@ -76,7 +76,7 @@
         <top>64</top>
         <width>390</width>
         <height>541</height>
-        <onleft>60</onleft>
+        <onleft>PreviousChannelGroup</onleft>
         <onright>60</onright>
         <onup>11</onup>
         <ondown>11</ondown>
@@ -240,7 +240,7 @@
         <textureslidernib>ScrollBarNib.png</textureslidernib>
         <textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
         <onleft>11</onleft>
-        <onright>11</onright>
+        <onright>NextChannelGroup</onright>
         <ondown>61</ondown>
         <onup>61</onup>
         <showonepage>false</showonepage>

--- a/720p/DialogSeekBar.xml
+++ b/720p/DialogSeekBar.xml
@@ -343,7 +343,7 @@
         <font>Font_Neon_Pause</font>
         <angle>90</angle>
         <textcolor>33ffffff</textcolor>
-        <visible>player.paused + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Paused + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -353,7 +353,7 @@
         <label>FFx2</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.forwarding2x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Forwarding2x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -363,7 +363,7 @@
         <label>FFx4</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.forwarding4x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Forwarding4x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -373,7 +373,7 @@
         <label>FFx8</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.forwarding8x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Forwarding8x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -383,7 +383,7 @@
         <label>FFx16</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.forwarding16x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Forwarding16x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -393,7 +393,7 @@
         <label>FFx32</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.forwarding32x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Forwarding32x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -403,7 +403,7 @@
         <label>RWx2</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.rewinding2x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Rewinding2x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -413,7 +413,7 @@
         <label>RWx4</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.rewinding4x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Rewinding4x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -423,7 +423,7 @@
         <label>RWx8</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.rewinding8x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Rewinding8x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -433,7 +433,7 @@
         <label>RWx16</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.rewinding16x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Rewinding16x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label" id="0">
         <left>0</left>
@@ -443,7 +443,7 @@
         <label>RWx32</label>
         <font>Font_Bartowski_BigMusic</font>
         <textcolor>33ffffff</textcolor>
-        <visible>player.rewinding32x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
+        <visible>Player.Rewinding32x + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
     </control>
     <control type="group">
@@ -454,7 +454,7 @@
         <effect type="fade" start="100" end="0" time="600" />
       </animation>
       <control type="label">
-        <right>250</right>
+        <right>325</right>
         <top>620</top>
         <width>1000</width>
         <height>25</height>
@@ -466,7 +466,7 @@
         <visible>VideoPlayer.Content(movies)+ ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label">
-        <right>250</right>
+        <right>325</right>
         <top>645</top>
         <width>1000</width>
         <height>25</height>
@@ -478,7 +478,7 @@
         <visible>VideoPlayer.Content(movies)+ ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label">
-        <right>250</right>
+        <right>325</right>
         <top>645</top>
         <width>1000</width>
         <height>25</height>
@@ -490,7 +490,7 @@
         <visible>VideoPlayer.Content(movies)+ Player.ChapterChapterName +![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label">
-        <right>250</right>
+        <right>325</right>
         <top>675</top>
         <width>1000</width>
         <height>25</height>
@@ -502,7 +502,7 @@
         <visible>VideoPlayer.Content(movies) + Player.ChapterCount + ![[Player.Paused + Player.Caching] + !Player.Seeking]</visible>
       </control>
       <control type="label">
-        <right>250</right>
+        <right>325</right>
         <top>675</top>
         <width>1000</width>
         <height>25</height>

--- a/720p/DialogVideoInfo.xml
+++ b/720p/DialogVideoInfo.xml
@@ -1220,7 +1220,7 @@
             <description>Play Trailer Windowed</description>
             <include>ButtonInfoDialogsCommonValues</include>
             <label>$LOCALIZE[20410]</label>
-            <onclick>PlayMedia($INFO[ListItem.Trailer],1)</onclick>
+            <onclick>PlayMedia($ESCINFO[ListItem.Trailer],1)</onclick>
             <visible>!IsEmpty(ListItem.Trailer) + Skin.HasSetting(WindowedTrailer)</visible>
           </control>
           <control type="button" id="113">

--- a/720p/PlayerControls.xml
+++ b/720p/PlayerControls.xml
@@ -40,9 +40,7 @@
         <height>40</height>
         <label>-</label>
         <texturefocus>osd/OSDRewindFO.png</texturefocus>
-        <texturenofocus>osd3
-				
-				/OSDRewindNF.png</texturenofocus>
+        <texturenofocus>osd/OSDRewindNF.png</texturenofocus>
         <onleft>600</onleft>
         <onright>603</onright>
         <onup>300</onup>

--- a/720p/SmartPlayListEditor.xml
+++ b/720p/SmartPlayListEditor.xml
@@ -5,7 +5,7 @@
   <coordinates>
     <system>1</system>
     <left>240</left>
-    <top>45</top>
+    <top>22</top>
   </coordinates>
   <include>dialogeffect</include>
   <controls>
@@ -17,7 +17,7 @@
         <left>0</left>
         <top>0</top>
         <width>800</width>
-        <height>630</height>
+        <height>675</height>
         <colordiffuse>mainblue</colordiffuse>
         <texture border="40">DialogBack.png</texture>
       </control>
@@ -81,7 +81,7 @@
       <control type="label">
         <description>Name Label</description>
         <left>30</left>
-        <top>125</top>
+        <top>120</top>
         <width>740</width>
         <label>21433</label>
         <font>Font_Neon_20</font>
@@ -91,7 +91,7 @@
       <control type="edit" id="12">
         <description>Name Button</description>
         <left>20</left>
-        <top>155</top>
+        <top>145</top>
         <width>760</width>
         <height>40</height>
         <textoffsetx>15</textoffsetx>
@@ -113,7 +113,7 @@
       <control type="label">
         <description>rules label</description>
         <left>30</left>
-        <top>210</top>
+        <top>200</top>
         <width>740</width>
         <align>left</align>
         <label>21434</label>
@@ -124,7 +124,7 @@
       <control type="list" id="10">
         <description>Rules List Control</description>
         <left>20</left>
-        <top>245</top>
+        <top>225</top>
         <width>560</width>
         <height>121</height>
         <onup>12</onup>
@@ -165,11 +165,12 @@
             <top>0</top>
             <width>560</width>
             <height>41</height>
+            <colordiffuse>mainblue</colordiffuse>
             <texture>MenuItemNF.png</texture>
             <visible>!Control.HasFocus(10)</visible>
           </control>
           <control type="label">
-            <left>10</left>
+            <left>20</left>
             <top>0</top>
             <width>540</width>
             <height>40</height>
@@ -181,10 +182,12 @@
         </focusedlayout>
       </control>
       <control type="group" id="9000">
+        <left>590</left>
+        <top>225</top>
         <control type="button" id="13">
           <description>Add Rule Button</description>
-          <left>600</left>
-          <top>245</top>
+          <left>0</left>
+          <top>0</top>
           <width>180</width>
           <height>41</height>
           <label>15019</label>
@@ -202,8 +205,8 @@
         </control>
         <control type="button" id="14">
           <description>Remove Rule Button</description>
-          <left>600</left>
-          <top>285</top>
+          <left>0</left>
+          <top>45</top>
           <height>41</height>
           <width>180</width>
           <label>1210</label>
@@ -221,8 +224,8 @@
         </control>
         <control type="button" id="15">
           <description>Edit Rule Button</description>
-          <left>600</left>
-          <top>325</top>
+          <left>0</left>
+          <top>90</top>
           <height>41</height>
           <width>180</width>
           <label>21435</label>
@@ -242,7 +245,7 @@
       <control type="label">
         <description>Name Label</description>
         <left>30</left>
-        <top>380</top>
+        <top>370</top>
         <width>740</width>
         <label>31325</label>
         <font>Font_Neon_20</font>
@@ -251,7 +254,7 @@
       </control>
       <control type="spincontrolex" id="16">
         <left>20</left>
-        <top>415</top>
+        <top>395</top>
         <width>760</width>
         <height>41</height>
         <label>21424</label>
@@ -268,7 +271,7 @@
       </control>
       <control type="spincontrolex" id="17">
         <left>20</left>
-        <top>455</top>
+        <top>440</top>
         <width>760</width>
         <height>41</height>
         <label>21427</label>
@@ -285,7 +288,7 @@
       </control>
       <control type="spincontrolex" id="18">
         <left>20</left>
-        <top>495</top>
+        <top>485</top>
         <width>560</width>
         <height>41</height>
         <label>21429</label>
@@ -298,16 +301,17 @@
         <onright>19</onright>
         <onleft>19</onleft>
         <onup>17</onup>
-        <ondown>9001</ondown>
+        <ondown>23</ondown>
       </control>
       <control type="togglebutton" id="19">
         <left>600</left>
-        <top>495</top>
+        <top>485</top>
         <width>180</width>
         <height>40</height>
         <font>Font_Neon_20</font>
         <align>center</align>
         <aligny>center</aligny>
+        <focusedcolor>white</focusedcolor>
         <colordiffuse>mainblue</colordiffuse>
         <texturenofocus border="5">MenuItemNF.png</texturenofocus>
         <texturefocus border="5">button-focus.png</texturefocus>
@@ -318,13 +322,49 @@
         <onright>18</onright>
         <onleft>18</onleft>
         <onup>17</onup>
+        <ondown>24</ondown>
+      </control>
+      <control type="spincontrolex" id="23">
+        <left>20</left>
+        <top>530</top>
+        <width>560</width>
+        <height>40</height>
+        <label>21458</label>
+        <font>Font_Neon_24</font>
+        <focusedcolor>white</focusedcolor>
+        <colordiffuse>mainblue</colordiffuse>
+        <textoffsetx>20</textoffsetx>
+        <texturefocus>MenuItemFOR.png</texturefocus>
+        <texturenofocus>MenuItemNF.png</texturenofocus>
+        <onright>24</onright>
+        <onleft>24</onleft>
+        <onup>18</onup>
+        <ondown>9001</ondown>
+      </control>
+      <control type="radiobutton" id="24">
+        <left>600</left>
+        <top>530</top>
+        <width>180</width>
+        <height>40</height>
+        <font>Font_Neon_20</font>
+        <aligny>center</aligny>
+        <textoffsetx>40</textoffsetx>
+        <radioposx>75</radioposx>
+        <focusedcolor>white</focusedcolor>
+        <colordiffuse>mainblue</colordiffuse>
+        <texturenofocus border="5">MenuItemNF.png</texturenofocus>
+        <texturefocus border="5">button-focus.png</texturefocus>
+        <label>21459</label>
+        <onright>23</onright>
+        <onleft>23</onleft>
+        <onup>19</onup>
         <ondown>9001</ondown>
       </control>
       <control type="group" id="9001">
         <control type="button" id="20">
           <description>Ok Button</description>
           <left>195</left>
-          <top>560</top>
+          <top>605</top>
           <width>200</width>
           <height>40</height>
           <align>center</align>
@@ -335,7 +375,7 @@
           <label>186</label>
           <focusedcolor>white</focusedcolor>
           <font>Font_Neon_20</font>
-          <onup>18</onup>
+          <onup>23</onup>
           <onleft>21</onleft>
           <onright>21</onright>
           <ondown>22</ondown>
@@ -343,7 +383,7 @@
         <control type="button" id="21">
           <description>Cancel Button</description>
           <left>405</left>
-          <top>560</top>
+          <top>605</top>
           <width>200</width>
           <height>40</height>
           <align>center</align>
@@ -354,7 +394,7 @@
           <texturefocus border="5">button-focus.png</texturefocus>
           <label>222</label>
           <font>Font_Neon_20</font>
-          <onup>18</onup>
+          <onup>23</onup>
           <onleft>20</onleft>
           <onright>20</onright>
           <ondown>22</ondown>

--- a/720p/Viewtype_Multiplex.xml
+++ b/720p/Viewtype_Multiplex.xml
@@ -240,7 +240,7 @@
             </control>
             <control type="image">
               <description>IMDB rating</description>
-              <posx />
+              <left>0</left>
               <top>40</top>
               <width>76</width>
               <height>18</height>


### PR DESCRIPTION
Changes to DialogPVRChannelsOSD to bring it inline with Gotham updates

SmartPlaylistEditor updated with Gotham changes

Capitalization fixed in DialogSeekBar as well as artwork layout for landscape items when video is paused

DialogVideoInfo updated to escape the path in case of local trailers

PlayerControls needed an image path fixed for rewind button

Viewtype_Multiplex updated to remove one <posx> reference
