### PR TITLE
Fix Remaining IDs and Format Settings Windows

### DIFF
--- a/720p/Custom_Overlay.xml
+++ b/720p/Custom_Overlay.xml
@@ -187,6 +187,16 @@
         <shadowcolor>FF000000</shadowcolor>
         <font>Font_RSS</font>
         <align>left</align>
+        <label>SkinSettings.xml</label>
+        <visible>Window.IsVisible(SkinSettings.xml)</visible>
+      </control>
+      <control type="label">
+        <width>780</width>
+        <height>21</height>
+        <textcolor>FF0000FF</textcolor>
+        <shadowcolor>FF000000</shadowcolor>
+        <font>Font_RSS</font>
+        <align>left</align>
         <label>SettingsCategory.xml</label>
         <visible>Window.IsVisible(SettingsCategory.xml)</visible>
       </control>

--- a/720p/DialogButtonMenu-lower.xml
+++ b/720p/DialogButtonMenu-lower.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--Alaska-->
-<window type="buttonMenu" id="111">
+<window type="buttonMenu">
   <defaultcontrol always="true">410</defaultcontrol>
   <include>Animation_SettingsFade</include>
   <animation effect="fade" start="0" end="100" time="300">Visible</animation>
@@ -56,7 +56,7 @@
         <align>center</align>
         <aligny>center</aligny>
         <label>5</label>
-        <onclick>ActivateWindow(4)</onclick>
+        <onclick>ActivateWindow(Settings)</onclick>
       </control>
       <control type="button" id="3111">
         <description>Filemanager</description>
@@ -164,7 +164,7 @@
         <align>center</align>
         <aligny>center</aligny>
         <label>$LOCALIZE[130]</label>
-        <onclick>ActivateWindow(7)</onclick>
+        <onclick>ActivateWindow(SystemInfo)</onclick>
       </control>
       <!--<control type="button" id="3116">
 				<description>Reload Skin</description>

--- a/720p/DialogButtonMenu.xml
+++ b/720p/DialogButtonMenu.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<window type="buttonMenu" id="111">
+<window type="buttonMenu">
   <defaultcontrol always="true">410</defaultcontrol>
   <include>Animation_SettingsFade</include>
   <animation effect="fade" start="0" end="100" time="300">Visible</animation>
@@ -78,7 +78,7 @@
         <align>center</align>
         <aligny>center</aligny>
         <label>5</label>
-        <onclick>ActivateWindow(4)</onclick>
+        <onclick>ActivateWindow(Settings)</onclick>
         <onup>SetFocus(3115)</onup>
       </control>
       <control type="button" id="3117">
@@ -213,7 +213,7 @@
         <align>center</align>
         <aligny>center</aligny>
         <label>$LOCALIZE[130]</label>
-        <onclick>ActivateWindow(7)</onclick>
+        <onclick>ActivateWindow(SystemInfo)</onclick>
         <ondown>SetFocus(3110)</ondown>
       </control>
     </control>

--- a/720p/DialogFavourites.xml
+++ b/720p/DialogFavourites.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Alaska-->
-<window type="dialog" id="134">
+<window type="dialog">
   <defaultcontrol always="true">450</defaultcontrol>
   <include>Animation_Bartowski_Context_Zoom</include>
   <controls>

--- a/720p/DialogSelect.xml
+++ b/720p/DialogSelect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog" id="2000">
+<window type="dialog">
   <defaultcontrol always="true">3</defaultcontrol>
   <zorder>3</zorder>
   <include>Animation_SettingsFade</include>

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -128,7 +128,7 @@
     <pulseonselect>false</pulseonselect>
   </include>
   <include name="skin_settings_labels">
-    <width>770</width>
+    <width>798</width>
     <height>34</height>
     <textoffsetx>30</textoffsetx>
     <font>Font_Neon_25</font>
@@ -139,7 +139,7 @@
     <texturenofocus>MenuItemNF.png</texturenofocus>
   </include>
   <include name="skin_settings_sub_labels">
-    <width>740</width>
+    <width>798</width>
     <height>34</height>
     <textoffsetx>40</textoffsetx>
     <font>Font_Neon_25</font>
@@ -150,7 +150,7 @@
     <texturenofocus>MenuItemNF.png</texturenofocus>
   </include>
   <include name="skin_settings_button">
-    <width>740</width>
+    <width>798</width>
     <height>34</height>
     <textoffsetx>40</textoffsetx>
     <font>Font_Neon_25</font>

--- a/720p/Includes_Home_Horizontal.xml
+++ b/720p/Includes_Home_Horizontal.xml
@@ -77,7 +77,7 @@
           <label>$LOCALIZE[31280]</label>
           <icon>special://skin/backgrounds/HDmovies.jpg</icon>
           <thumb>$INFO[Skin.String(CustomHDMoviesFolder)]</thumb>
-          <onclick>ActivateWindow(10025,special://skin/playlists/HDMovies.xsp,return)</onclick>
+          <onclick>ActivateWindow(Videos,special://skin/playlists/HDMovies.xsp,return)</onclick>
           <visible>!Skin.HasSetting(HomeMenuNoHDMoviesButton) + Library.HasContent(Movies)</visible>
         </item>
         <item id="5">
@@ -108,7 +108,7 @@
           <label>$INFO[Skin.String(Menu_Custom6_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom6_Folder)]</thumb>
-          <!-- <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom6_Path)],return)</onclick> -->
+          <!-- <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom6_Path)],return)</onclick> -->
           <onclick>XBMC.PlayMedia($ESCINFO[Skin.String(Menu_Custom6_Path)])</onclick>
           <onclick>ReplaceWindow(Home)</onclick>
           <visible>Skin.HasSetting(Menu_Custom6) + Skin.HasSetting(Menu_Custom6_Play)</visible>
@@ -118,7 +118,7 @@
           <label>$INFO[Skin.String(Menu_Custom6_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom6_Folder)]</thumb>
-          <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom6_Path)],return)</onclick>
+          <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom6_Path)],return)</onclick>
           <!-- <onclick>XBMC.PlayMedia($ESCINFO[Skin.String(Menu_Custom6_Path)])</onclick> -->
           <visible>Skin.HasSetting(Menu_Custom6) + !Skin.HasSetting(Menu_Custom6_Play)</visible>
         </item>
@@ -135,7 +135,7 @@
           <label>$INFO[Skin.String(Menu_Custom7_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom7_Folder)]</thumb>
-          <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom7_Path)],return)</onclick>
+          <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom7_Path)],return)</onclick>
           <visible>Skin.HasSetting(Menu_Custom7) + !Skin.HasSetting(Menu_Custom7_Play)</visible>
         </item>
         <item id="23">
@@ -151,7 +151,7 @@
           <label>$INFO[Skin.String(Menu_Custom8_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom8_Folder)]</thumb>
-          <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom8_Path)],return)</onclick>
+          <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom8_Path)],return)</onclick>
           <visible>Skin.HasSetting(Menu_Custom8) + !Skin.HasSetting(Menu_Custom8_Play)</visible>
         </item>
         <item id="24">
@@ -167,7 +167,7 @@
           <label>$INFO[Skin.String(Menu_Custom9_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom9_Folder)]</thumb>
-          <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom9_Path)],return)</onclick>
+          <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom9_Path)],return)</onclick>
           <visible>Skin.HasSetting(Menu_Custom9) + !Skin.HasSetting(Menu_Custom9_Play)</visible>
         </item>
         <item id="25">
@@ -183,7 +183,7 @@
           <label>$INFO[Skin.String(Menu_Custom10_Label)]</label>
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom10_Folder)]</thumb>
-          <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom10_Path)],return)</onclick>
+          <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom10_Path)],return)</onclick>
           <visible>Skin.HasSetting(Menu_Custom10) + !Skin.HasSetting(Menu_Custom10_Play)</visible>
         </item>
         <item id="15">
@@ -263,7 +263,7 @@
           <label>8</label>
           <icon>special://skin/backgrounds/weather.jpg</icon>
           <thumb>$INFO[Skin.String(Home_Custom_Back_Weather_Folder)]</thumb>
-          <onclick>xbmc.activatewindow(2600)</onclick>
+          <onclick>ActivateWindow(Weather)</onclick>
           <visible>!Skin.HasSetting(HomeMenuNoWeatherButton) + !Skin.HasSetting(conditions_weather_backdrop)</visible>
         </item>
         <item id="8">
@@ -271,7 +271,7 @@
           <label>8</label>
           <icon>special://skin/backgrounds/weather.jpg</icon>
           <thumb>$INFO[Skin.String(Home_Custom_Back_Weather_Folder1)]$INFO[Weather.FanartCode]</thumb>
-          <onclick>xbmc.activatewindow(2600)</onclick>
+          <onclick>ActivateWindow(Weather)</onclick>
           <visible>!Skin.HasSetting(HomeMenuNoWeatherButton) + Skin.HasSetting(conditions_weather_backdrop)</visible>
         </item>
         <item id="9">
@@ -477,7 +477,7 @@
           </item>
           <item id="2">
             <label>$INFO[Skin.String(Menu_Custom12_Label)]</label>
-            <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom12_Path)],return)</onclick>
+            <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom12_Path)],return)</onclick>
             <visible>Skin.HasSetting(Menu_Custom12)</visible>
           </item>
           <item id="3">
@@ -572,7 +572,7 @@
           </item>
           <item id="2">
             <label>$INFO[Skin.String(Menu_Custom14_Label)]</label>
-            <onclick>XBMC.ActivateWindow(10025,$INFO[Skin.String(Menu_Custom14_Path)],return)</onclick>
+            <onclick>XBMC.ActivateWindow(Videos,$INFO[Skin.String(Menu_Custom14_Path)],return)</onclick>
             <visible>Skin.HasSetting(Menu_Custom14)</visible>
           </item>
           <item id="3">

--- a/720p/MusicOSD.xml
+++ b/720p/MusicOSD.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog" id="120">
+<window type="dialog">
   <defaultcontrol always="true">602</defaultcontrol>
   <controls>
     <control type="group">
@@ -75,7 +75,7 @@
           <onright>800</onright>
           <onup>601</onup>
           <ondown>601</ondown>
-          <onclick>ActivateWindow(122)</onclick>
+          <onclick>ActivateWindow(VisualisationPresetList)</onclick>
         </control>
       </control>
       <control type="image" id="11">

--- a/720p/MyVideoNav.xml
+++ b/720p/MyVideoNav.xml
@@ -144,7 +144,7 @@
       <include>ScrollOffsetLabel</include>
     </control>
     <control type="group">
-      <visible>!SubString(Window(25).Property(tvtunesIsAlive),True)</visible>
+      <visible>!SubString(Window(Videos).Property(tvtunesIsAlive),True)</visible>
       <include>RSS_Music</include>
     </control>
     <!--		<include>7000_has_focus</include> -->

--- a/720p/PlayerControls.xml
+++ b/720p/PlayerControls.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog" id="114">
+<window type="dialog">
   <defaultcontrol always="true">603</defaultcontrol>
   <visible>Player.HasMedia + Window.IsActive(PlayerControls) + !Window.IsActive(FullscreenVideo) + !Window.IsActive(Visualisation)</visible>
   <coordinates>

--- a/720p/Settings.xml
+++ b/720p/Settings.xml
@@ -26,13 +26,14 @@
       </control>
       <control type="button">
         <description>Close Window button</description>
-        <left>1015</left>
+        <left>1005</left>
         <top>9</top>
         <width>64</width>
         <height>32</height>
         <label>-</label>
         <font>-</font>
         <onclick>PreviousMenu</onclick>
+        <colordiffuse>mainblue</colordiffuse>
         <texturefocus>DialogCloseButton-focus.png</texturefocus>
         <texturenofocus>DialogCloseButton.png</texturenofocus>
         <onleft>1</onleft>
@@ -54,7 +55,7 @@
       <control type="list" id="9000">
         <left>10</left>
         <top>102</top>
-        <width>365</width>
+        <width>260</width>
         <height>541</height>
         <onleft>9000</onleft>
         <onright>9001</onright>
@@ -66,14 +67,14 @@
           <control type="image">
             <left>0</left>
             <top>0</top>
-            <width>265</width>
+            <width>260</width>
             <height>45</height>
             <texture>MenuItemNF.png</texture>
           </control>
           <control type="label">
             <left>130</left>
             <top>0</top>
-            <width>385</width>
+            <width>260</width>
             <height>45</height>
             <font>font24caps_title</font>
             <textcolor>grey3</textcolor>
@@ -94,7 +95,7 @@
           <control type="label">
             <left>130</left>
             <top>0</top>
-            <width>385</width>
+            <width>260</width>
             <height>45</height>
             <font>font24caps_title</font>
             <textcolor>white</textcolor>
@@ -162,9 +163,9 @@
         </content>
       </control>
       <control type="image">
-        <left>268</left>
+        <left>270</left>
         <top>10</top>
-        <width>824</width>
+        <width>800</width>
         <height>618</height>
         <texture border="5">black-back2.png</texture>
       </control>
@@ -189,16 +190,16 @@
         <shadowcolor>black</shadowcolor>
       </control>
       <control type="image">
-        <left>270</left>
+        <left>278</left>
         <top>60</top>
-        <width>800</width>
+        <width>785</width>
         <height>450</height>
         <texture border="5">button-nofocus.png</texture>
       </control>
       <control type="image">
-        <left>272</left>
+        <left>280</left>
         <top>62</top>
-        <width>796</width>
+        <width>781</width>
         <height>446</height>
         <aspectratio>stretch</aspectratio>
         <fadetime>600</fadetime>

--- a/720p/SettingsCategory.xml
+++ b/720p/SettingsCategory.xml
@@ -46,13 +46,14 @@
       </control>
       <control type="button">
         <description>Close Window button</description>
-        <left>1015</left>
+        <left>1005</left>
         <top>9</top>
         <width>64</width>
         <height>32</height>
         <label>-</label>
         <font>-</font>
         <onclick>PreviousMenu</onclick>
+        <colordiffuse>mainblue</colordiffuse>
         <texturefocus>DialogCloseButton-focus.png</texturefocus>
         <texturenofocus>DialogCloseButton.png</texturenofocus>
         <onleft>1</onleft>
@@ -73,55 +74,54 @@
       </control>
       <control type="grouplist" id="3">
         <description>button area</description>
-        <left>9</left>
+        <left>10</left>
         <top>102</top>
         <width>260</width>
         <height>481</height>
-        <itemgap>-1</itemgap>
         <onleft>60</onleft>
         <onright>5</onright>
         <onup>3</onup>
         <ondown>20</ondown>
       </control>
       <control type="button" id="20">
-				<description>Setting level button</description>
-				<left>10</left>
-				<top>562</top>
-				<height>60</height>
-				<width>260</width>
-				<label>10037</label>
-				<textoffsetx>20</textoffsetx>
-				<textoffsety>28</textoffsety>
-				<align>right</align>
-				<aligny>top</aligny>
-				<font>font13caps</font>
-				<textcolor>selected</textcolor>
+        <description>Setting level button</description>
+        <left>10</left>
+        <top>562</top>
+        <height>60</height>
+        <width>260</width>
+        <label>10037</label>
+        <textoffsetx>20</textoffsetx>
+        <textoffsety>28</textoffsety>
+        <align>right</align>
+        <aligny>top</aligny>
+        <font>font13caps</font>
+        <textcolor>selected</textcolor>
         <focusedcolor>selected</focusedcolor>
         <colordiffuse>mainblue</colordiffuse>
         <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
         <texturenofocus>MenuItemNF.png</texturenofocus>
         <pulseonselect>true</pulseonselect>
-				<onleft>5</onleft>
-				<onright>5</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<onclick>SettingsLevelChange</onclick>
-			</control>
+        <onleft>5</onleft>
+        <onright>5</onright>
+        <onup>3</onup>
+        <ondown>3</ondown>
+        <onclick>SettingsLevelChange</onclick>
+      </control>
       <control type="label">
-				<left>20</left>
-				<top>566</top>
-				<height>25</height>
-				<width>230</width> 
-				<label>31016</label> 
-				<font>font13_title</font> 
-				<textcolor>white</textcolor> 
-				<align>right</align> 
-				<aligny>center</aligny>
-			</control>
+        <left>20</left>
+        <top>566</top>
+        <height>25</height>
+        <width>230</width> 
+        <label>31016</label> 
+        <font>font13_title</font> 
+        <textcolor>white</textcolor> 
+        <align>right</align> 
+        <aligny>center</aligny>
+      </control>
       <control type="image">
-        <left>268</left>
+        <left>270</left>
         <top>10</top>
-        <width>824</width>
+        <width>800</width>
         <height>618</height>
         <texture border="5">black-back2.png</texture>
       </control>
@@ -147,9 +147,9 @@
       </control>
       <control type="grouplist" id="5">
         <description>control area</description>
-        <left>269</left>
+        <left>271</left>
         <top>70</top>
-        <width>805</width>
+        <width>798</width>
         <height>435</height>
         <itemgap>-1</itemgap>
         <pagecontrol>60</pagecontrol>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -5,7 +5,7 @@
     <include>CommonSettingsBackground</include>
     <include>CommonMediaPlayingBackground</include>
     <control type="group">
-      <left>90</left>
+      <left>80</left>
       <top>50</top>
       <animation type="WindowOpen" reversible="false">
         <!--	<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" /> -->
@@ -23,6 +23,24 @@
         <colordiffuse>mainblue</colordiffuse>
         <texture border="20">DialogBack.png</texture>
       </control>
+      <control type="button">
+        <description>Close Window button</description>
+        <left>1005</left>
+        <top>9</top>
+        <width>64</width>
+        <height>32</height>
+        <label>-</label>
+        <font>-</font>
+        <onclick>PreviousMenu</onclick>
+        <colordiffuse>mainblue</colordiffuse>
+        <texturefocus>DialogCloseButton-focus.png</texturefocus>
+        <texturenofocus>DialogCloseButton.png</texturenofocus>
+        <onleft>1</onleft>
+        <onright>1</onright>
+        <onup>1</onup>
+        <ondown>1</ondown>
+        <visible>system.getbool(input.enablemouse)</visible>
+      </control>
       <control type="image">
         <description>LOGO</description>
         <left>30</left>
@@ -36,7 +54,7 @@
       <control type="list" id="9000">
         <left>10</left>
         <top>102</top>
-        <width>281</width>
+        <width>260</width>
         <height>481</height>
         <itemgap>-1</itemgap>
         <onleft>9010</onleft>
@@ -45,19 +63,19 @@
         <ondown>9000</ondown>
         <pagecontrol>-</pagecontrol>
         <scrolltime>300</scrolltime>
-        <itemlayout height="60" width="261">
+        <itemlayout height="52" width="261">
           <control type="image">
             <left>0</left>
             <top>0</top>
-            <width>280</width>
+            <width>260</width>
             <height>45</height>
             <texture>MenuItemNF.png</texture>
           </control>
           <control type="label">
-            <left>135</left>
-            <top>-10</top>
-            <width>230</width>
-            <!-- <height>25</height> -->
+            <left>130</left>
+            <top>0</top>
+            <width>260</width>
+            <height>45</height>
             <font>font24caps_title</font>
             <textcolor>grey3</textcolor>
             <textoffsetx>10</textoffsetx>
@@ -66,22 +84,20 @@
             <label>$INFO[ListItem.Label]</label>
           </control>
         </itemlayout>
-        <focusedlayout height="60" width="261">
+        <focusedlayout height="52" width="261">
           <control type="image">
             <left>0</left>
-            <top>4</top>
-            <width>280</width>
+            <top>0</top>
+            <width>260</width>
             <height>45</height>
             <colordiffuse>mainblue</colordiffuse>
             <texture>mainmenu/home_bottom_white.png</texture>
-            <animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
           </control>
           <control type="label">
-            <left>135</left>
-            <top>-10</top>
-            <width>230</width>
-            <!--<height>25</height> -->
-            <!-- <textoffsetx>10</textoffsetx> -->
+            <left>130</left>
+            <top>0</top>
+            <width>260</width>
+            <height>45</height>
             <font>font24caps_title</font>
             <textcolor>white</textcolor>
             <textoffsetx>10</textoffsetx>
@@ -141,9 +157,23 @@
           </item>
         </content>
       </control>
+      <control type="image">
+        <left>270</left>
+        <top>10</top>
+        <width>800</width>
+        <height>618</height>
+        <texture border="5">black-back2.png</texture>
+      </control>
+      <control type="image">
+        <left>268</left>
+        <top>50</top>
+        <width>805</width>
+        <aspectratio>stretch</aspectratio>
+        <texture>common/separator.png</texture>
+      </control>
       <control type="label">
         <description>header label</description>
-        <left>320</left>
+        <left>300</left>
         <top>20</top>
         <width>740</width>
         <height>30</height>
@@ -154,29 +184,15 @@
         <textcolor>white</textcolor>
         <shadowcolor>black</shadowcolor>
       </control>
-      <control type="image">
-        <left>290</left>
-        <top>10</top>
-        <width>770</width>
-        <height>615</height>
-        <texture>black-back2.png</texture>
-      </control>
-      <control type="image">
-        <left>268</left>
-        <top>50</top>
-        <width>805</width>
-        <aspectratio>stretch</aspectratio>
-        <texture>common/separator.png</texture>
-      </control>
       <control type="group" id="9010">
         <control type="grouplist" id="9001">
           <visible>Container(9000).Hasfocus(1)</visible>
-          <left>290</left>
-          <top>60</top>
-          <width>860</width>
+          <left>271</left>
+          <top>70</top>
+          <width>798</width>
           <height>530</height>
           <itemgap>-1</itemgap>
-          <pagecontrol>-</pagecontrol>
+          <pagecontrol>61</pagecontrol>
           <onleft>9000</onleft>
           <onright>9000</onright>
           <onup>9001</onup>
@@ -234,31 +250,23 @@
             <width>740</width>
             <height>45</height>
             <label>$LOCALIZE[512]</label>
-            <textoffsetx>15</textoffsetx>
             <font>Font_Neon_20</font>
+            <textoffsetx>15</textoffsetx>
             <textcolor>mainblue</textcolor>
             <shadowcolor>black</shadowcolor>
             <align>left</align>
             <aligny>center</aligny>
           </control>
           <control type="radiobutton" id="121">
-            <width>770</width>
-            <height>40</height>
-            <font>Font_KeyboardKeys</font>
+            <include>skin_settings_labels</include>
             <label>$LOCALIZE[21398]</label>
-            <textoffsetx>30</textoffsetx>
-            <textcolor>grey2</textcolor>
-            <focusedcolor>white</focusedcolor>
-            <colordiffuse>mainblue</colordiffuse>
-            <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-            <texturenofocus>MenuItemNF.png</texturenofocus>
             <onclick>Skin.ToggleSetting(Use_Startup_Playlist)</onclick>
             <selected>Skin.HasSetting(Use_Startup_Playlist)</selected>
             <onclick>Skin.Reset(Use_Intro_Movie)</onclick>
           </control>
           <control type="button" id="122">
             <description>Startup Playlist Path</description>
-            <width>740</width>
+            <width>813</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
             <textcolor>grey2</textcolor>
@@ -275,16 +283,7 @@
           <control type="radiobutton" id="123">
             <description>Use Intro Movie</description>
             <include>skin_settings_labels</include>
-            <width>740</width>
-            <height>30</height>
             <label>$LOCALIZE[31010]</label>
-            <font>Font_KeyboardTitle</font>
-            <textoffsetx>30</textoffsetx>
-            <textcolor>grey2</textcolor>
-            <focusedcolor>white</focusedcolor>
-            <colordiffuse>mainblue</colordiffuse>
-            <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-            <texturenofocus>MenuItemNF.png</texturenofocus>
             <onclick>Skin.ToggleSetting(Use_Intro_Movie)</onclick>
             <selected>Skin.HasSetting(Use_Intro_Movie)</selected>
             <onclick>Skin.Reset(Use_Startup_Playlist)</onclick>
@@ -328,12 +327,12 @@
         </control>
         <control type="grouplist" id="9002">
           <visible>Container(9000).Hasfocus(2)</visible>
-          <left>290</left>
-          <top>60</top>
-          <width>860</width>
+          <left>271</left>
+          <top>70</top>
+          <width>798</width>
           <height>530</height>
           <itemgap>-1</itemgap>
-          <pagecontrol>60</pagecontrol>
+          <pagecontrol>61</pagecontrol>
           <onleft>9000</onleft>
           <onright>60</onright>
           <onup>9002</onup>
@@ -379,8 +378,9 @@
           </control>
           <control type="radiobutton" id="2021">
             <description>Use Random Items</description>
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
+            <radioposx>640</radioposx>
             <font>Font_KeyboardTitle</font>
             <textoffsetx>40</textoffsetx>
             <label>$LOCALIZE[31516]</label>
@@ -395,9 +395,10 @@
           </control>
           <control type="radiobutton" id="2022">
             <description>Show Large Recently added tvinfo</description>
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
+            <radioposx>640</radioposx>
             <textoffsetx>40</textoffsetx>
             <label>$LOCALIZE[31979]</label>
             <textcolor>grey2</textcolor>
@@ -411,9 +412,10 @@
           </control>
           <control type="radiobutton" id="2023">
             <description>Show Large Recently added tvinfo</description>
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
+            <radioposx>640</radioposx>
             <textoffsetx>40</textoffsetx>
             <label>$LOCALIZE[31980]</label>
             <textcolor>grey2</textcolor>
@@ -427,9 +429,10 @@
           </control>
           <control type="radiobutton" id="2024">
             <description>Only show Albums in music view</description>
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
+            <radioposx>640</radioposx>
             <textoffsetx>40</textoffsetx>
             <label>$LOCALIZE[31011]</label>
             <textcolor>grey2</textcolor>
@@ -448,7 +451,7 @@
             <selected>Skin.HasSetting(global_bottomline)</selected>
           </control>
           <control type="button" id="229">
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
             <textcolor>grey2</textcolor>
@@ -479,7 +482,7 @@
             <selected>Skin.HasSetting(conditions_weather_backdrop)</selected>
           </control>
           <control type="button" id="206">
-            <width>740</width>
+            <width>798</width>
             <height>30</height>
             <font>Font_KeyboardTitle</font>
             <focusedcolor>white</focusedcolor>
@@ -501,9 +504,10 @@
           </control>
           <control type="radiobutton" id="208">
             <description>Global Ken Burns</description>
-            <width>770</width>
+            <width>798</width>
             <height>26</height>
             <font>Font_KeyboardTitle</font>
+            <radioposx>640</radioposx>
             <textoffsetx>40</textoffsetx>
             <textoffsety>4</textoffsety>
             <textcolor>grey2</textcolor>
@@ -712,7 +716,7 @@
             <onright>300</onright>
             <onup>9003</onup>
             <ondown>9003</ondown>
-            <pagecontrol>-</pagecontrol>
+            <pagecontrol>61</pagecontrol>
             <scrolltime>0</scrolltime>
             <itemlayout height="1" width="860"></itemlayout>
             <focusedlayout height="40" width="860">
@@ -2286,9 +2290,9 @@
         <control type="group">
           <control type="grouplist" id="9004">
             <visible>Container(9000).Hasfocus(4)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -2297,9 +2301,10 @@
             <onup>9004</onup>
             <ondown>9004</ondown>
             <control type="label" id="400">
-              <width>860</width>
+              <width>740</width>
               <height>45</height>
-              <font>Font_KeyboardKeys</font>
+              <font>Font_Neon_20</font>
+              <textoffsetx>15</textoffsetx>
               <label>Add Submenu of Custom Scripts on Home</label>
               <textcolor>mainblue</textcolor>
               <align>left</align>
@@ -2516,29 +2521,13 @@
 						</control>-->
           </control>
         </control>
-        <control type="scrollbar" id="61">
-          <left>1060</left>
-          <top>60</top>
-          <width>25</width>
-          <height>530</height>
-          <texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
-          <texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
-          <texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
-          <textureslidernib>ScrollBarNib.png</textureslidernib>
-          <textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
-          <onleft>9004</onleft>
-          <onright>9000</onright>
-          <showonepage>false</showonepage>
-          <orientation>vertical</orientation>
-          <visible>Container(9000).Hasfocus(4)</visible>
-        </control>
         <control type="group">
           <!--Movies/TV-->
           <control type="grouplist" id="9005">
             <visible>Container(9000).Hasfocus(5)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -2547,7 +2536,7 @@
             <onup>9005</onup>
             <ondown>9005</ondown>
             <control type="label" id="500">
-              <width>860</width>
+              <width>740</width>
               <height>45</height>
               <font>Font_Neon_20</font>
               <textoffsetx>15</textoffsetx>
@@ -2645,9 +2634,10 @@
               <align>left</align>
             </control>
             <control type="radiobutton" id="5100">
-              <width>770</width>
-              <height>45</height>
-              <font>Font_Neon_24</font>
+              <width>798</width>
+              <height>30</height>
+              <font>Font_KeyboardTitle</font>
+              <radioposx>640</radioposx>
               <textoffsetx>40</textoffsetx>
               <textcolor>grey2</textcolor>
               <focusedcolor>white</focusedcolor>
@@ -2682,77 +2672,32 @@
               <aligny>center</aligny>
             </control>
             <control type="button" id="514">
-              <left>0</left>
-              <width>740</width>
-              <height>40</height>
-              <font>Font_Neon_24</font>
-              <textoffsetx>25</textoffsetx>
+              <include>skin_settings_labels</include>
               <label>$LOCALIZE[31264]</label>
-              <textcolor>grey2</textcolor>
-              <focusedcolor>white</focusedcolor>
-              <colordiffuse>mainblue</colordiffuse>
-              <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-              <texturenofocus>MenuItemNF.png</texturenofocus>
               <onclick>XBMC.RunScript(script.artwork.downloader, mode=custom, mediatype=tvshow, clearlogo)</onclick>
               <visible>system.hasaddon(script.artwork.downloader)</visible>
             </control>
             <control type="button" id="517">
-              <left>0</left>
-              <width>740</width>
-              <height>40</height>
-              <font>Font_Neon_24</font>
-              <textoffsetx>25</textoffsetx>
+              <include>skin_settings_labels</include>
               <label>$LOCALIZE[31973]</label>
-              <textcolor>grey2</textcolor>
-              <focusedcolor>white</focusedcolor>
-              <colordiffuse>mainblue</colordiffuse>
-              <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-              <texturenofocus>MenuItemNF.png</texturenofocus>
               <onclick>XBMC.RunScript(script.artwork.downloader, mode=custom, poster)</onclick>
               <visible>system.hasaddon(script.artwork.downloader)</visible>
             </control>
             <control type="button" id="518">
-              <left>0</left>
-              <width>740</width>
-              <height>40</height>
-              <font>Font_Neon_24</font>
-              <textoffsetx>25</textoffsetx>
+              <include>skin_settings_labels</include>
               <label>$LOCALIZE[31974]</label>
-              <textcolor>grey2</textcolor>
-              <focusedcolor>white</focusedcolor>
-              <colordiffuse>mainblue</colordiffuse>
-              <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-              <texturenofocus>MenuItemNF.png</texturenofocus>
               <onclick>XBMC.RunScript(script.artwork.downloader, mode=custom, banner)</onclick>
               <visible>system.hasaddon(script.artwork.downloader)</visible>
             </control>
             <control type="button" id="519">
-              <left>0</left>
-              <width>740</width>
-              <height>40</height>
-              <font>Font_Neon_24</font>
-              <textoffsetx>25</textoffsetx>
+              <include>skin_settings_labels</include>
               <label>$LOCALIZE[31975]</label>
-              <textcolor>grey2</textcolor>
-              <focusedcolor>white</focusedcolor>
-              <colordiffuse>mainblue</colordiffuse>
-              <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-              <texturenofocus>MenuItemNF.png</texturenofocus>
               <onclick>XBMC.RunScript(script.artwork.downloader, mode=custom, defaultthumb)</onclick>
               <visible>system.hasaddon(script.artwork.downloader)</visible>
             </control>
             <control type="button" id="520">
-              <left>0</left>
-              <width>740</width>
-              <height>40</height>
-              <font>Font_Neon_24</font>
-              <textoffsetx>25</textoffsetx>
+              <include>skin_settings_labels</include>
               <label>$LOCALIZE[31976]</label>
-              <textcolor>grey2</textcolor>
-              <focusedcolor>white</focusedcolor>
-              <colordiffuse>mainblue</colordiffuse>
-              <texturefocus>mainmenu/home_bottom_white.png</texturefocus>
-              <texturenofocus>MenuItemNF.png</texturenofocus>
               <onclick>XBMC.RunScript(script.artwork.downloader, mode=custom, clearart)</onclick>
               <visible>system.hasaddon(script.artwork.downloader)</visible>
             </control>
@@ -2774,9 +2719,9 @@
           <!--Music-->
           <control type="grouplist" id="9008">
             <visible>Container(9000).Hasfocus(6)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -2787,8 +2732,8 @@
             <control type="label" id="112">
               <width>740</width>
               <height>45</height>
-              <textoffsetx>15</textoffsetx>
               <font>Font_Neon_20</font>
+              <textoffsetx>15</textoffsetx>
               <label>$LOCALIZE[31038]</label>
               <textcolor>mainblue</textcolor>
               <shadowcolor>black</shadowcolor>
@@ -2802,9 +2747,10 @@
               <selected>Skin.HasSetting(FanartNoVisualisation)</selected>
             </control>
             <control type="radiobutton" id="114">
-              <width>740</width>
-              <height>40</height>
+              <width>798</width>
+              <height>30</height>
               <font>Font_KeyboardTitle</font>
+              <radioposx>640</radioposx>
               <textoffsetx>40</textoffsetx>
               <label>$LOCALIZE[31041]</label>
               <textcolor>grey2</textcolor>
@@ -2817,9 +2763,10 @@
               <visible>Skin.HasSetting(FanartNoVisualisation)</visible>
             </control>
             <control type="radiobutton" id="115">
-              <width>740</width>
-              <height>40</height>
+              <width>798</width>
+              <height>30</height>
               <font>Font_KeyboardTitle</font>
+              <radioposx>640</radioposx>
               <textoffsetx>40</textoffsetx>
               <label>$LOCALIZE[31257]</label>
               <textcolor>grey2</textcolor>
@@ -2832,9 +2779,10 @@
               <visible>!IsEmpty(Skin.String(CustomMusicFolder)) + Skin.HasSetting(FanartNoVisualisation)</visible>
             </control>
             <control type="radiobutton" id="116">
-              <width>740</width>
-              <height>40</height>
+              <width>798</width>
+              <height>30</height>
               <font>Font_KeyboardTitle</font>
+              <radioposx>640</radioposx>
               <textoffsetx>40</textoffsetx>
               <label>$LOCALIZE[31258]</label>
               <textcolor>grey2</textcolor>
@@ -2896,9 +2844,9 @@
           <!--Reset Skin-->
           <control type="grouplist" id="9009">
             <visible>Container(9000).Hasfocus(9)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -2909,6 +2857,8 @@
             <control type="label" id="600">
               <width>860</width>
               <height>45</height>
+              <font>Font_Neon_20</font>
+              <textoffsetx>15</textoffsetx>
               <label>Reset all Skin Settings</label>
               <textcolor>red</textcolor>
               <shadowcolor>black</shadowcolor>
@@ -2927,9 +2877,9 @@
           <!--Disable Views-->
           <control type="grouplist" id="9006">
             <visible>Container(9000).Hasfocus(8)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -2941,6 +2891,7 @@
               <width>860</width>
               <height>45</height>
               <font>Font_Neon_20</font>
+              <textoffsetx>15</textoffsetx>
               <label>$LOCALIZE[31047]</label>
               <textcolor>mainblue</textcolor>
               <shadowcolor>black</shadowcolor>
@@ -3041,6 +2992,7 @@
               <width>860</width>
               <height>45</height>
               <font>Font_Neon_20</font>
+              <textoffsetx>15</textoffsetx>
               <label>$LOCALIZE[31065]</label>
               <textcolor>mainblue</textcolor>
               <shadowcolor>black</shadowcolor>
@@ -3076,9 +3028,9 @@
         <control type="group">
           <control type="grouplist" id="9007">
             <visible>Container(9000).Hasfocus(7)</visible>
-            <left>290</left>
-            <top>60</top>
-            <width>860</width>
+            <left>271</left>
+            <top>70</top>
+            <width>798</width>
             <height>530</height>
             <itemgap>-1</itemgap>
             <pagecontrol>61</pagecontrol>
@@ -3632,6 +3584,22 @@
               <visible>Skin.HasSetting(Menu_Custom18) + Skin.String(MoviesCustom,18)</visible>
             </control>
           </control>
+        </control>
+        <control type="scrollbar" id="61">
+          <left>1068</left>
+          <top>65</top>
+          <width>25</width>
+          <height>530</height>
+          <texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
+          <texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
+          <texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
+          <textureslidernib>ScrollBarNib.png</textureslidernib>
+          <textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
+          <onleft>9004</onleft>
+          <onright>9000</onright>
+          <showonepage>false</showonepage>
+          <orientation>vertical</orientation>
+          <visible>!Container(9000).Hasfocus(3)</visible>
         </control>
       </control>
     </control>

--- a/720p/VideoOSD.xml
+++ b/720p/VideoOSD.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog" id="2901">
+<window type="dialog">
   <defaultcontrol always="true">602</defaultcontrol>
   <controls>
     <!--	<control type="image">
@@ -40,7 +40,7 @@
           <onright>701</onright>
           <onup>600</onup>
           <ondown>600</ondown>
-          <onclick>ActivateWindow(125)</onclick>
+          <onclick>ActivateWindow(VideoBookmarks)</onclick>
         </control>
         <control type="button" id="701">
           <left>50</left>
@@ -70,7 +70,7 @@
           <onright>703</onright>
           <onup>601</onup>
           <ondown>601</ondown>
-          <onclick>ActivateWindow(123)</onclick>
+          <onclick>ActivateWindow(OSDVideoSettings)</onclick>
         </control>
       </control>
       <control type="image" id="11">

--- a/720p/custom_DialogBottomLine_1199.xml
+++ b/720p/custom_DialogBottomLine_1199.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog" id="1199">
+<window type="dialog">
   <defaultcontrol always="true">9000</defaultcontrol>
   <controls>
     <control type="image">

--- a/720p/custom_DialogFavourites.xml
+++ b/720p/custom_DialogFavourites.xml
@@ -52,7 +52,7 @@
         <width>720</width>
         <height>60</height>
         <align>center</align>
-        <textcolor>black</textcolor>
+        <textcolor>mainblue</textcolor>
         <label>$LOCALIZE[1036]</label>
         <font>Font_Neon_45_Context</font>
       </control>
@@ -109,124 +109,124 @@
         </focusedlayout>
         <content>
           <item id="1">
-            <label>$INFO[Window(0).Property(favourite.1.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.1.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.1.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.1.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.1.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.1.name))</visible>
           </item>
           <item id="2">
-            <label>$INFO[Window(0).Property(favourite.2.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.2.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.2.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.2.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.2.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.2.name))</visible>
           </item>
           <item id="3">
-            <label>$INFO[Window(0).Property(favourite.3.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.3.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.3.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.3.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.3.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.3.name))</visible>
           </item>
           <item id="4">
-            <label>$INFO[Window(0).Property(favourite.4.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.4.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.4.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.4.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.4.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.4.name))</visible>
           </item>
           <item id="5">
-            <label>$INFO[Window(0).Property(favourite.5.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.5.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.5.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.5.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.5.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.5.name))</visible>
           </item>
           <item id="6">
-            <label>$INFO[Window(0).Property(favourite.6.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.6.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.6.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.6.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.6.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.6.name))</visible>
           </item>
           <item id="7">
-            <label>$INFO[Window(0).Property(favourite.7.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.7.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.7.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.7.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.7.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.7.name))</visible>
           </item>
           <item id="8">
-            <label>$INFO[Window(0).Property(favourite.8.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.8.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.8.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.8.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.8.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.8.name))</visible>
           </item>
           <item id="9">
-            <label>$INFO[Window(0).Property(favourite.9.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.9.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.9.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.9.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.9.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.9.name))</visible>
           </item>
           <item id="10">
-            <label>$INFO[Window(0).Property(favourite.10.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.10.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.10.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.10.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.10.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.10.name))</visible>
           </item>
           <item id="11">
-            <label>$INFO[Window(0).Property(favourite.11.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.11.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.11.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.11.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.11.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.11.name))</visible>
           </item>
           <item id="12">
-            <label>$INFO[Window(0).Property(favourite.12.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.12.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.12.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.12.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.12.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.12.name))</visible>
           </item>
           <item id="13">
-            <label>$INFO[Window(0).Property(favourite.13.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.13.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.13.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.13.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.13.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.13.name))</visible>
           </item>
           <item id="14">
-            <label>$INFO[Window(0).Property(favourite.14.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.14.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.14.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.14.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.14.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.14.name))</visible>
           </item>
           <item id="15">
-            <label>$INFO[Window(0).Property(favourite.15.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.15.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.15.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.15.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.15.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.15.name))</visible>
           </item>
           <item id="16">
-            <label>$INFO[Window(0).Property(favourite.16.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.16.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.16.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.16.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.16.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.16.name))</visible>
           </item>
           <item id="17">
-            <label>$INFO[Window(0).Property(favourite.17.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.17.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.17.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.17.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.17.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.17.name))</visible>
           </item>
           <item id="18">
-            <label>$INFO[Window(0).Property(favourite.18.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.18.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.18.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.18.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.18.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.18.name))</visible>
           </item>
           <item id="19">
-            <label>$INFO[Window(0).Property(favourite.19.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.19.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.19.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.19.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.19.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.19.name))</visible>
           </item>
           <item id="20">
-            <label>$INFO[Window(0).Property(favourite.20.name)]</label>
-            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(0).Property(favourite.20.path)])</onclick>
+            <label>$INFO[Window(Home).Property(favourite.20.name)]</label>
+            <onclick>Skin.SetString($INFO[Skin.String(Menu_Sub_Custom_Favourites_Path)],$INFO[Window(Home).Property(favourite.20.path)])</onclick>
             <onclick>Dialog.Close(1114)</onclick>
-            <visible>!IsEmpty(Window(0).Property(favourite.20.name))</visible>
+            <visible>!IsEmpty(Window(Home).Property(favourite.20.name))</visible>
           </item>
         </content>
       </control>


### PR DESCRIPTION
Found some remaining window id's that needed to be cleaned up.

Cleaned up references to windows by id instead of by name.

Added SkinSettings.xml to the Custom_Overlay

Formatted the 3 settings windows to have the same look/feel for consistency.  SkinSettings needed to be cleaned up for Gotham.
