### PR TITLE
Fix Homepage Animation

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -455,7 +455,7 @@
       <left>0</left>
       <top>0</top>
       <control type="group">
-        <animation effect="slide" start="300,0" end="0,0" time="500">WindowOpen</animation>
+        <animation effect="slide" start="-300,0" end="0,0" time="500">WindowOpen</animation>
         <animation effect="slide" start="0,0" end="-300,0" time="400">WindowClose</animation>
         <control type="image">
 		  <left>-180</left>


### PR DESCRIPTION
Date animation slid in from wrong side.  Corrected to match time animation.  Due to commit 50c31f446d2b21a76942cc22a2db142e932d4760
