### PR TITLE
Minor Cleanup

### DIFF
--- a/720p/DialogVideoInfo.xml
+++ b/720p/DialogVideoInfo.xml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <window>
-<onload condition="!Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
-	<onload condition="System.HasAddon(script.videoextras)">XBMC.RunScript(script.videoextras,check,"$INFO[ListItem.FilenameAndPath]")</onload>
-	<onload condition="System.HasAddon(script.videoextras)"> XBMC.RunScript(script.videoextras,hasExtras,flag,"$INFO[ListItem.FilenameAndPath]")</onload>
+  <onload condition="!Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
+  <onload condition="System.HasAddon(script.videoextras)">XBMC.RunScript(script.videoextras,check,"$INFO[ListItem.FilenameAndPath]")</onload>
   <defaultcontrol always="true">8</defaultcontrol>
   <allowoverlay>no</allowoverlay>
   <controls>

--- a/addon.xml
+++ b/addon.xml
@@ -21,21 +21,21 @@
     <res width="1280" height="720" aspect="16:9" default="true" folder="720p" />
   </extension>
   <extension point="xbmc.addon.metadata">
-    <summary>Neon skin by stoli - Night meets Aeon meets Confluence</summary>
+    <summary lang="en">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
     <summary lang="fr">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
     <summary lang="de">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
-	<summary lang="nl">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
-	<summary lang="no">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
+    <summary lang="nl">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
+    <summary lang="no">Neon skin by stoli - Night meets Aeon meets Confluence</summary>
     <description lang="en">Neon started as the excelent Night skin by mcborzu.  It was almost perfect for me but I missed some aspects of Aeon and other skins.  So credit where credit is due - the majority of this originated as mcborzu's work...and inspiration from djh_ and huge thanks for Jezz_x's work on Conflunce where I have 'borrowed' liberal amounts of knowledge, code and graphics!</description>
- 	<disclaimer>More info on the skin can be found at the XBMC Forums.</disclaimer>
+    <disclaimer lang="en">More info on the skin can be found at the XBMC Forums.</disclaimer>
     <disclaimer lang="fr">Plus d'infos sur ce thème sur les forums XBMC.</disclaimer>
     <disclaimer lang="de">Mehr Informationen über das Skin findest du in den XBMC Foren.</disclaimer>
-	<disclaimer lang="nl">Meer info over de skin kan worden gevonden op de XBMC forums.</disclaimer>
-	<disclaimer lang="no">Du kan finne mer info i XBMC forumene.</disclaimer>
+    <disclaimer lang="nl">Meer info over de skin kan worden gevonden op de XBMC forums.</disclaimer>
+    <disclaimer lang="no">Du kan finne mer info i XBMC forumene.</disclaimer>
     <platform>all</platform>
-	<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-	<forum>http://forum.xbmc.org/forumdisplay.php?fid=139</forum>
-	<source>http://github.com/stoli/skin.neon</source>
-	<email></email>
+    <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
+    <forum>http://forum.xbmc.org/forumdisplay.php?fid=139</forum>
+    <source>http://github.com/stoli/skin.neon</source>
+    <email></email>
   </extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,35 +1,9 @@
 [b]Changelog:[/b]
 
-[b]2.5.9[/b]
-- prevent Artist Slideshow from showing up twice (#13) 
-- Add Sets button to Movies submenu
-- Landpanel shows correct images at TVShow level
-- Bottom RSS not shown when XBMC global setting disables all RSS
-- Implemented skinsetting to change global weather
-- Smaller CodecInfo font so VDPAU info fits correctly
-- Fix restart XBMC option in shutdown menu
-- [Slide] Fix Fullscreen trailer
-- [Wall] Fix thumbnails
-- Neon settings added to Settings submenu
-[b]2.5.8[/b]
-- Pressing up-button from Homebar Settings does not navigate to empty view anymore. (#09)
-- Fixed alignment of all recent and random items (#07) 
-- Added skin setting for 'songs rather than albums' (defaults to albums)
-- 'Use large recent TV-Shows' now functional and selectable.
-- Fixed an issue that prevented playing recent items when those items were on a smb-fileshare
-- Progressbar centered in screen (Stoli #04)
-- Norwegian language corrected (Stoli #03)
-- Settings menu glued back together (never noticed it became disjointed) 
-- Removed the extra clearlogo that was right through the text in info screen
-- Removed unused fonts
-[b]2.5.7[/b]
-- Use Shutdown instead of Poweroff when choosing shutdown in main menu
-- Fanart shown using database calls instead of fixed locations, to comply with Frodo (#08)
-- Skin now correctly using DejaVu font
-- Video watched overlay status added to Multiplex view
-- Random items now functional, still need to be aligned properly (#02)
-[b]2.5.6[/b]
-- Initial add for XBMC Frodo
+[b]3.0.2[/b]
+- Fix VideoExtras script loading in DialogVideoInfo
+[b]3.0.1[/b]
+- Initial add for XBMC Gotham
 
 [b]Skin history:[/b]
 Stoli wrote and designed this excellent skin in oktober 2010 for XBMC Dharma. 


### PR DESCRIPTION
Removed past change log notes to restart at 3.0.1 release for Gotham.

Fixed VideoExtras onload condition per Karandras.

Fixed addon.xml to have a language for each summary/disclaimer and fixed spacing.
