### PR TITLE
Fix Includes and Custom Playlists

### DIFF
--- a/720p/Includes_Home_Horizontal.xml
+++ b/720p/Includes_Home_Horizontal.xml
@@ -176,7 +176,7 @@
           <icon>special://skin/backgrounds/custom.jpg</icon>
           <thumb>$INFO[Skin.String(Menu_Custom10_Folder)]</thumb>
           <onclick>XBMC.PlayMedia($ESCINFO[Skin.String(Menu_Custom10_Path)])</onclick>
-          <visible>Skin.HasSetting(Menu_Custom10)</visible>
+          <visible>Skin.HasSetting(Menu_Custom10) + Skin.HasSetting(Menu_Custom10_Play)</visible>
         </item>
         <item id="25">
           <description>Custom Playlist 5</description>

--- a/720p/Includes_TVGuide.xml
+++ b/720p/Includes_TVGuide.xml
@@ -14,17 +14,6 @@
           <aspectratio>scale</aspectratio>
           <texture>special://skin/backgrounds/programs.jpg</texture>
         </control>
-        <control type="image">
-          <left>0</left>
-          <top>0</top>
-          <width>1280</width>
-          <height>720</height>
-          <texture background="true">$VAR[NextAiredFanart]</texture>
-          <aspectratio>scale</aspectratio>
-          <fadetime>FanartCrossfadeTime</fadetime>
-          <include>VisibleFadeEffect</include>
-          <visible>!IsEmpty(Window(Home).Property(TVGuide.BackgroundFanart))</visible>
-        </control>
       </control>
       <control type="grouplist">
         <left>40</left>


### PR DESCRIPTION
$VAR[NextAiredFanart] was uninitialized, remove the call to unused image

Fix Custom Playlist 5 functionality on the homescreen
