### PR TITLE
Fix Shutdown Menu

### DIFF
--- a/720p/DialogButtonMenu.xml
+++ b/720p/DialogButtonMenu.xml
@@ -8,7 +8,13 @@
     <control type="button" id="410">
       <onfocus>Dialog.Close(2003)</onfocus>
       <onfocus>Dialog.Close(106)</onfocus>
-      <onfocus>SetFocus(3110)</onfocus>
+      <onfocus>down</onfocus>
+      <texturefocus>-</texturefocus>
+      <texturenofocus>-</texturenofocus>
+      <onleft>1</onleft>
+      <onright>1</onright>
+      <onup>1</onup>
+      <ondown>3110</ondown>
     </control>
     <control type="grouplist" id="1">
       <left>458</left>

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Changelog:
 
 3.0.6
 - Clean-up unused font includes
+- Fix shutdown menu for systems without exit option
 3.0.5
 - Fix 3d Playback Options in Video OSD (again)
 - Add advanced filtering options where supported


### PR DESCRIPTION
For systems without an exit option the list was not working correctly
